### PR TITLE
dctrems:hasLicense replace with dctrems:license

### DIFF
--- a/sto.ttl
+++ b/sto.ttl
@@ -155,11 +155,6 @@ xsd:gYear rdf:type rdfs:Datatype .
 #    Object Properties
 #################################################################
 
-###  http://purl.org/dc/terms/hasLicense
-dcterms:hasLicense rdf:type owl:ObjectProperty ;
-                   rdfs:domain sto:Standard ;
-                   rdfs:range dcterms:LicenseDocument .
-
 
 ###  http://purl.org/dc/terms/language
 dcterms:language rdf:type owl:ObjectProperty .
@@ -3239,6 +3234,30 @@ sto:GPLv2 rdf:type owl:NamedIndividual ,
           rdfs:label "GNU General Public License"@en ;
           rdfs:seeAlso <https://opcfoundation.org/license/gpl.htm> ;
           skos:prefLabel "OCL 1.0" .
+		  
+		  
+###  https://w3id.org/i40/sto#PrivateLicenseDocument
+sto:PrivateLicenseDocument rdf:type owl:NamedIndividual ,
+                   dcterms:LicenseDocument ;
+          rdfs:comment "Published under a Private License."@en ;
+          rdfs:label "Private License"@en ;
+          rdfs:seeAlso <https://en.wikipedia.org/wiki/Trade_secret> .
+		  
+		  
+###  https://w3id.org/i40/sto#PublicLicenseDocument
+sto:PublicLicenseDocument rdf:type owl:NamedIndividual ,
+                   dcterms:LicenseDocument ;
+          rdfs:comment "Published under a Public License."@en ;
+          rdfs:label "Public License"@en ;
+          rdfs:seeAlso <https://en.wikipedia.org/wiki/Public_copyright_license> .
+		  
+		  
+###  https://w3id.org/i40/sto#OpenLicenseDocument
+sto:OpenLicenseDocument rdf:type owl:NamedIndividual ,
+                   dcterms:LicenseDocument ;
+          rdfs:comment "Open or Free License"@en ;
+          rdfs:label "Open or Free License"@en ;
+          rdfs:seeAlso <https://en.wikipedia.org/wiki/Free_license> .
 
 
 ###  https://w3id.org/i40/sto#HTML
@@ -5651,7 +5670,7 @@ sto:IEC_61508 rdf:type owl:NamedIndividual ,
               sto:relatedTo sto:IEC_61511 ;
               sto:hasPublicationDate "1997-02-28"^^xsd:date ;
               sto:hasTag "Functional Safety of Electrical/Electronic/Programmable Electronic Safety-related Systems"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "Functional safety is a concept applicable across all industry sectors. It is fundamental to the enabling of complex technology used for safety-related systems. It provides the assurance that the safety-related systems will offer the necessary risk reduction required to achieve safety for the equipment. The oil and gas industry, nuclear plants and the machinery sector, to name but a few, all rely heavily on functional safety to achieve safety for the equipment giving rise to the hazards."@en ;
               rdfs:label "IEC 61508"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/IEC_61508> ;
@@ -5671,7 +5690,7 @@ sto:IEC_61511 rdf:type owl:NamedIndividual ,
                             sto:ISO_13849 ;
               sto:hasPublicationDate "2016-02-24"^^xsd:date ;
               sto:hasTag "Functional safety - Safety instrumented systems for the process industry sector"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "IEC 61511 is a technical standard which sets out practices in the engineering of systems that ensure the safety of an industrial process through the use of instrumentation."@en ;
               rdfs:label "IEC 61511" ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/IEC_61511> ;
@@ -5773,7 +5792,7 @@ sto:IEC_61784 rdf:type owl:NamedIndividual ,
               sto:relatedTo sto:IEC_61158 ;
               sto:hasPublicationDate "2014-08-19"^^xsd:date ;
               sto:hasTag "IEC Fieldbus (Profibus)"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "Industrial communication networks - Profiles - Ethernet-real-time-enabled"@en ;
               rdfs:label "IEC 61784"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/page/Profibus> ;
@@ -5872,7 +5891,7 @@ sto:IEC_61987_X rdf:type owl:NamedIndividual ,
                                       rami:WorkCenter ;
                 sto:hasPublisher sto:IEC ;
                 sto:hasTag "LOPs in PA"@en ;
-                dcterms:hasLicense "Private"@en ;
+                dcterms:license sto:PrivateLicenseDocument ;
                 rdfs:comment "Industrial-process measurement and control - Data structures and elements in process equipment catalogs - Measuring equipment with analogue and digital output"@en ;
                 rdfs:label "IEC 61987_X"@en ;
                 sto:hasMotivation "Properties and LOPs as an informational representation of the features of measuring equipment. The referenced standards define general principles (e.g. part 11) as well as specific LOPs for specific device types. These international standards also may serve as examples for description of products."@en ;
@@ -5902,7 +5921,7 @@ sto:IEC_62264 rdf:type owl:NamedIndividual ,
               sto:relatedTo sto:ISA-95 ;
               sto:hasTag "Enterprise control systems"@en ,
                          "Enterprise-control system integration"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "Enterprise-control system integration - Models and terminology"@en ,
                            "IEC 62264 is an international standard for enterprise-control system integration. This standard is based upon ANSI/ISA-95."@en ;
               rdfs:label "IEC 62264"@en ;
@@ -5952,7 +5971,7 @@ sto:IEC_62424 rdf:type owl:NamedIndividual ,
               dul:isComponentOf sto:IEC_62714 ;
               sto:hasPublisher sto:IEC ;
               sto:hasTag "CAEX"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "CAEX (Computer Aided Engineering Exchange) is a neutral data format that allows storage of hierarchical object information, e.g. the hierarchical architecture of a plant. On a certain abstraction level, a plant consists in modules or components that are interconnected. CAEX allows storage of those modules or components by means of objects. Object oriented concepts as encapsulation, classes, class libraries, instances, instance hierarchies, inheritance, relations, attributes and interfaces are explicitly supported. CAEX bases on XML and is defined as XML schema (xsd file). The original intention of developing CAEX was the industrial lack of a common and established data exchange between process engineering tools and process control engineering tools. However, CAEX can be applied to all types of static object information, e.g. plant topologies, document topologies, product topologies, petri nets, but also for non-technical applications like phylogenetic trees."@en ;
               rdfs:label "IEC 62424"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/CAEX> ;
@@ -5975,7 +5994,7 @@ sto:IEC_62443 rdf:type owl:NamedIndividual ,
                                sto:ISA ;
               sto:hasTag "Electronically secure Industrial Automation and Control Systems"@en ,
                          "Network and system security for industrial-process measurement and control"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "Defines procedures for implementing electronically secure Industrial Automation and Control Systems."@en ,
                            "ISA/IEC-62443 is a series of standards, technical reports, and related information that define procedures for implementing electronically secure Industrial Automation and Control Systems (IACS). This guidance applies to end-users (i.e. asset owner), system integrators, security practitioners, and control systems manufacturers responsible for manufacturing, designing, implementing, or managing industrial automation and control systems."@en ;
               rdfs:label "IEC 62443"@en ;
@@ -6006,7 +6025,7 @@ sto:IEC_62453 rdf:type owl:NamedIndividual ,
 ###  https://w3id.org/i40/sto#IEC_62541
 sto:IEC_62541 rdf:type owl:NamedIndividual ,
                        sto:Standard ;
-              dcterms:hasLicense sto:GPLv2 ;
+              dcterms:license sto:GPLv2 ;
               sto:hasAvailableLanguage lang:eng ;
               sto:hasClassification iira:ApplicationDomain ,
                                     iira:InformationDomain ,
@@ -6031,7 +6050,7 @@ sto:IEC_62541 rdf:type owl:NamedIndividual ,
                             sto:IEC_62714 ;
               sto:useStructureOf sto:IEC_61804 ;
               sto:hasTag "OPC UA"@en ;
-              dcterms:hasLicense "Open"@en ;
+              dcterms:license sto:OpenLicenseDocument ;
               rdfs:comment "OPC Unified Architecture (OPC UA) is an industrial M2M communication protocol for interoperability developed by the OPC Foundation. It is the successor to Open Platform Communications (OPC). Although developed by the same organization, OPC UA differs significantly from its predecessor. The Foundation's goal for this project was to provide a path forward from the original OPC communications model (namely the Microsoft Windows only process exchange COM/DCOM) to a cross-platform service-oriented architecture (SOA) for process control, while enhancing security and providing an information model."@en ;
               rdfs:label "IEC 62541"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/OPC_Unified_Architecture> ;
@@ -6076,7 +6095,7 @@ sto:IEC_62714 rdf:type owl:NamedIndividual ,
               sto:uses sto:MathML ;
               sto:hasTag "AML"@en ,
                          "AutomationML"@en ;
-              dcterms:hasLicense "Open"@en ;
+              dcterms:license sto:OpenLicenseDocument ;
               rdfs:comment "Engineering data exchange format for use in industrial automation systems engineering - Automation markup language - Architecture and general requirements"@en ;
               rdfs:label "IEC 62714"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/AutomationML> ;
@@ -6118,7 +6137,7 @@ sto:IEC_62890 rdf:type owl:NamedIndividual ,
                                     sto:ProductionLifeCycleDataManagement ;
               sto:hasPublisher sto:IEC ;
               sto:hasTag "IEC 62890"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "Defines standards for lifecycle management for systems and products used in industrial process measurement, control and automation"@en ,
                            "MES KPIs"@en ;
               rdfs:label "IEC 62890"@en ;
@@ -6167,7 +6186,7 @@ sto:IEC_TR_62794 rdf:type owl:NamedIndividual ,
                  sto:hasPublisher sto:IEC ;
                  sto:relatedTo sto:IEC_TS_62832 ;
                  sto:hasTag "DF/TR"@en ;
-                 dcterms:hasLicense "Private"@en ;
+                 dcterms:license sto:PrivateLicenseDocument ;
                  rdfs:comment "Industrial-process measurement, control and automation - Reference model for representation of production facilities (digital factory)"@en ;
                  rdfs:label "IEC TR 62794"@en ;
                  sto:hasMotivation "The standards for Digital Factory define methods and information models, which are required for self description of I40-components. "@en ;
@@ -6203,7 +6222,7 @@ sto:IEC_TS_62832 rdf:type owl:NamedIndividual ,
                                        rami:WorkCenter ;
                  sto:hasPublisher sto:IEC ;
                  sto:hasTag "DF/TS"@en ;
-                 dcterms:hasLicense "Private"@en ;
+                 dcterms:license sto:PrivateLicenseDocument ;
                  rdfs:comment "Digital Factory Reference model TS"@en ;
                  rdfs:label "IEC TS 62832"@en ;
                  sto:hasMotivation "The standards for Digital Factory define methods and information models, which are required for self description of I40-components. IEC TS 62832 defines methods, which allow to validate or plan connections between assets."@en ;
@@ -6443,7 +6462,7 @@ sto:ISO_13584 rdf:type owl:NamedIndividual ,
               sto:relatedTo sto:IEC_61360 ,
                             sto:eClass ;
               sto:hasTag "Industrial automation systems and integration"@en ;
-              dcterms:hasLicense "Private"@en ;
+              dcterms:license sto:PrivateLicenseDocument ;
               rdfs:comment "ISO 13584 is a series of International Standards for the computer-sensible representation and exchange of parts library data. The objective is to provide a mechanism capable of transferring parts library data, independent from any particular system. The nature of this description makes it suitable not only for the exchange of files containing parts libraries, but also as a basis for implementing and sharing databases of parts library data, and archiving"@en ;
               rdfs:label "ISO 13584"@en ;
               sto:hasDBpediaResource <http://dbpedia.org/resource/ISO_13584> ;
@@ -8534,7 +8553,7 @@ sto:W3C_OWL rdf:type owl:NamedIndividual ,
             sto:hasPublisher sto:W3C ;
             sto:relatedTo sto:W3C_RDF ;
             sto:hasTag "OWL"@en ;
-            dcterms:hasLicense "Public"@en ;
+            dcterms:license sto:PublicLicenseDocument ;
             rdfs:comment "The W3C Web Ontology Language (OWL) is a Semantic Web language designed to represent rich and complex knowledge about things, groups of things, and relations between things. OWL is a computational logic-based language such that knowledge expressed in OWL can be exploited by computer programs, e.g., to verify the consistency of that knowledge or to make implicit knowledge explicit. OWL documents, known as ontologies, can be published in the World Wide Web and may refer to or be referred from other OWL ontologies. OWL is part of the W3C’s Semantic Web technology stack, which includes RDF, RDFS, SPARQL, etc."@en ;
             rdfs:label "Web Ontology Language"@en ;
             sto:hasDBpediaResource <http://dbpedia.org/resource/Web_Ontology_Language> ;
@@ -8547,7 +8566,7 @@ sto:W3C_RDF rdf:type owl:NamedIndividual ,
                      sto:Standard ;
             sto:hasPublisher sto:W3C ;
             sto:hasTag "RDF"@en ;
-            dcterms:hasLicense "Public"@en ;
+            dcterms:license sto:PublicLicenseDocument ;
             rdfs:comment "RDF is a standard model for data interchange on the Web. RDF has features that facilitate data merging even if the underlying schemas differ, and it specifically supports the evolution of schemas over time without requiring all the data consumers to be changed. "@en ;
             rdfs:label "Resource Description Framework"@en ;
             sto:hasDBpediaResource <http://dbpedia.org/resource/Resource_Description_Framework> ;
@@ -8561,7 +8580,7 @@ sto:W3C_RIF rdf:type owl:NamedIndividual ,
             sto:hasPublisher sto:W3C ;
             sto:relatedTo sto:W3C_OWL ;
             sto:hasTag "RIF"@en ;
-            dcterms:hasLicense "Public"@en ;
+            dcterms:license sto:PublicLicenseDocument ;
             rdfs:comment "The Rule Interchange Format (RIF) is a W3C Recommendation. RIF is part of the infrastructure for the semantic web, along with (principally) SPARQL, RDF and OWL. Although originally envisioned by many as a rules layer for the semantic web, in reality the design of RIF is based on the observation that there are many rules languages in existence, and what is needed is to exchange rules between them."@en ;
             rdfs:label "Rule Interchange Format"@en ;
             sto:hasDBpediaResource <http://dbpedia.org/resource/Rule_Interchange_Format> ;
@@ -8575,7 +8594,7 @@ sto:W3C_SPARQL rdf:type owl:NamedIndividual ,
                sto:hasPublisher sto:W3C ;
                sto:relatedTo sto:W3C_RDF ;
                sto:hasTag "SPARQL"@en ;
-               dcterms:hasLicense "Public"@en ;
+               dcterms:license sto:PublicLicenseDocument ;
                rdfs:comment "The SPARQL Protocol and RDF Query Language (SPARQL) is a query language and protocol for RDF. This document specifies the SPARQL Protocol; it describes a means for conveying SPARQL queries and updates to a SPARQL processing service and returning the results via HTTP to the entity that requested them. This protocol was developed by the W3C SPARQL Working Group, part of the Semantic Web Activity as described in the activity statement ."@en ;
                rdfs:label "SPARQL"@en ;
                sto:hasDBpediaResource <http://dbpedia.org/resource/SPARQL> ;
@@ -8712,7 +8731,7 @@ und Standardisierung."""@de ,
                                         sto:hasDeveloper sto:VDI ;
                                         sto:hasPublisher sto:VDI ;
                                         dcterms:creator "sebastian" ;
-                                        dcterms:hasLicense "private"@en ;
+                                        dcterms:license sto:PrivateLicenseDocument ;
                                         dcterms:title "IT-security for industrial automation"@en ,
                                                       "Informationssicherheit in der industriellen Automatisierung"@de ;
                                         rdfs:comment "This guideline describes how specific measures can be implemented in order to guarantee the IT security of automated machines and plant; aspects of the automation devices, automation systems, and automation applications used are considered. A uniform, feasible procedure for ensuring IT security throughout the entire life cycle of automation devices, systems, and applications is described, based on common terms and definitions agreed by the manufacturers of automation devices and systems and their users (e.g., machine manufacturers, integrators, operators). The life cycle covers the development, integration, operation, migration, and decommissioning phases.This guideline defines a simple procedure model for the development and description of IT Security. The model consists of eight steps."@en ;


### PR DESCRIPTION
This is a proposed change related to dcterms:license object property usage.
The following changes are included:
-Replaced object property dcterms:hasLicense with dcterms:license.
-Replaced dataProperty punning of dcterms:hasLicense with ObjectPropertyusage:

dcTerms:hasLicense "Private"@en ; ->dcTerms:license sto:PrivateLicenseDocument
dcterms:hasLicense "Public"@en ; -> dcterms:license sto:PublicLicenseDocument
dcterms:hasLicense "Open"@en ; -> dcterms:license sto:OpenLicenseDocument

-Added Individuals
sto:OpenLicenseDocument
sto:PublicLicenseDocument
sto:OpenLicenseDocument