### PR TITLE
Removed ObjectProperty sto:hasTag

### DIFF
--- a/sto.ttl
+++ b/sto.ttl
@@ -403,11 +403,6 @@ sto:hasPublisher rdf:type owl:ObjectProperty ;
                  rdfs:label "has Publisher"@en .
 
 
-###  https://w3id.org/i40/sto#hasTag
-sto:hasTag rdf:type owl:ObjectProperty ;
-           rdfs:domain sto:Publication .
-
-
 ###  https://w3id.org/i40/sto#hasTechnicalCommittee
 sto:hasTechnicalCommittee rdf:type owl:ObjectProperty ;
                           rdfs:domain sto:Publication ;


### PR DESCRIPTION
Removed ObjectPropery sto:hasTag to allow only for DataProperty sto:hasTage, since punning an IRI for more than one property types is currently unsupported.
See: https://www.w3.org/TR/owl2-new-features/#F12:_Punning