### PR TITLE
first version of JS crawler and results

### DIFF
--- a/StandardsCrawler.js
+++ b/StandardsCrawler.js
@@ -1,0 +1,357 @@
+/*
+ *
+ * JavaScript crawler for IEC standards.
+ *
+ * How to use it:
+ * 1. open one of the links from the urls array below.
+ * 2. open the browser console (e.g. [F12])
+ *      This must be done in the tab with a website from the iec server. Otherwise the cross-origin-policy will forbid to automatically open any of the other websites.
+ * 3. copy the whole content of this file into the console
+ * 4. execute the code with enter
+ * 5. wait untill all links have been opened and a download appears
+ * 6. replace ",sto" with "\nsto"
+ * 7. done!
+ *
+*/
+
+
+
+// original link list
+var urls = ["https://webstore.iec.ch/publication/7433",
+"https://webstore.iec.ch/publication/153",
+"https://webstore.iec.ch/publication/96",
+"https://webstore.iec.ch/publication/587",
+"https://webstore.iec.ch/publication/22991",
+"https://webstore.iec.ch/publication/1022",
+"https://webstore.iec.ch/publication/1165",
+"https://webstore.iec.ch/publication/1166",
+"https://webstore.iec.ch/publication/1160",
+"https://webstore.iec.ch/publication/1172",
+"https://webstore.iec.ch/publication/1258",
+"https://webstore.iec.ch/publication/1259",
+"https://webstore.iec.ch/publication/63037",
+"https://webstore.iec.ch/publication/1949",
+"https://webstore.iec.ch/publication/1948",
+"https://webstore.iec.ch/publication/1950",
+"https://webstore.iec.ch/publication/1950",
+"https://webstore.iec.ch/publication/24120",
+"https://webstore.iec.ch/publication/3666",
+"https://webstore.iec.ch/publication/3669",
+"https://webstore.iec.ch/publication/3671",
+"https://webstore.iec.ch/publication/3672",
+"https://webstore.iec.ch/publication/3673",
+"https://webstore.iec.ch/publication/3674",
+"https://webstore.iec.ch/publication/3675",
+"https://webstore.iec.ch/publication/3684",
+"https://webstore.iec.ch/publication/3727",
+"https://webstore.iec.ch/publication/3728",
+"https://webstore.iec.ch/publication/3738",
+"https://webstore.iec.ch/publication/3739",
+"https://webstore.iec.ch/publication/23822",
+"https://webstore.iec.ch/publication/3744",
+"https://webstore.iec.ch/publication/3745",
+"https://webstore.iec.ch/publication/25035",
+"https://webstore.iec.ch/publication/3742",
+"https://webstore.iec.ch/publication/3747",
+"https://webstore.iec.ch/publication/3748",
+"https://webstore.iec.ch/publication/3749",
+"https://webstore.iec.ch/publication/3750",
+"https://webstore.iec.ch/publication/3751",
+"https://webstore.iec.ch/publication/3757",
+"https://webstore.iec.ch/publication/3758",
+"https://webstore.iec.ch/publication/3759",
+"https://webstore.iec.ch/publication/3760",
+"https://webstore.iec.ch/publication/3765",
+"https://webstore.iec.ch/publication/3767",
+"https://webstore.iec.ch/publication/3768",
+"https://webstore.iec.ch/publication/3769",
+"https://webstore.iec.ch/publication/3881",
+"https://webstore.iec.ch/publication/3961",
+"https://webstore.iec.ch/publication/25629",
+"https://webstore.iec.ch/publication/25400",
+"https://webstore.iec.ch/publication/60204",
+"https://webstore.iec.ch/publication/25399",
+"https://webstore.iec.ch/publication/4550",
+"https://webstore.iec.ch/publication/4550",
+"https://webstore.iec.ch/publication/4707",
+"https://webstore.iec.ch/publication/5263",
+"https://webstore.iec.ch/publication/5264",
+"https://webstore.iec.ch/publication/5265",
+"https://webstore.iec.ch/publication/5308",
+"https://webstore.iec.ch/publication/5308",
+"https://webstore.iec.ch/publication/5297",
+"https://webstore.iec.ch/publication/5298",
+"https://webstore.iec.ch/publication/5299",
+"https://webstore.iec.ch/publication/5300",
+"https://webstore.iec.ch/publication/5301",
+"https://webstore.iec.ch/publication/5302",
+"https://webstore.iec.ch/publication/5303",
+"https://webstore.iec.ch/publication/5304",
+"https://webstore.iec.ch/publication/5305",
+"https://webstore.iec.ch/publication/5306",
+"https://webstore.iec.ch/publication/5307",
+"https://webstore.iec.ch/publication/5313",
+"https://webstore.iec.ch/publication/5380",
+"https://webstore.iec.ch/publication/26603",
+"https://webstore.iec.ch/publication/61087",
+"https://webstore.iec.ch/publication/22813",
+"https://webstore.iec.ch/publication/22808",
+"https://webstore.iec.ch/publication/59497",
+"https://webstore.iec.ch/publication/26560",
+"https://webstore.iec.ch/publication/32580",
+"https://webstore.iec.ch/publication/5506",
+"https://webstore.iec.ch/publication/5513",
+"https://webstore.iec.ch/publication/24241",
+"https://webstore.iec.ch/publication/5528",
+"https://webstore.iec.ch/publication/5532",
+"https://webstore.iec.ch/publication/5723",
+"https://webstore.iec.ch/publication/5724",
+"https://webstore.iec.ch/publication/5726",
+"https://webstore.iec.ch/publication/5878",
+"https://webstore.iec.ch/publication/5953",
+"https://webstore.iec.ch/publication/33869",
+"https://webstore.iec.ch/publication/5963",
+"https://webstore.iec.ch/publication/6225",
+"https://webstore.iec.ch/publication/22797",
+"https://webstore.iec.ch/publication/6675",
+"https://webstore.iec.ch/publication/22781",
+"https://webstore.iec.ch/publication/6871",
+"https://webstore.iec.ch/publication/25442",
+"https://webstore.iec.ch/publication/7029",
+"https://webstore.iec.ch/publication/7033",
+"https://webstore.iec.ch/publication/7040",
+"https://webstore.iec.ch/publication/24433",
+"https://webstore.iec.ch/publication/24433",
+"https://webstore.iec.ch/publication/7326",
+"https://webstore.iec.ch/publication/7446",
+"https://webstore.iec.ch/publication/30082",
+"https://webstore.iec.ch/publication/6626",
+"https://webstore.iec.ch/publication/33023",
+"https://webstore.iec.ch/publication/5380",
+"https://webstore.iec.ch/publication/62997",
+"https://webstore.iec.ch/publication/10334",
+"https://webstore.iec.ch/publication/11190",
+"https://webstore.iec.ch/publication/11351",
+"https://webstore.iec.ch/publication/60834",
+"https://webstore.iec.ch/publication/11411",
+"https://webstore.iec.ch/publication/11978",
+"https://webstore.iec.ch/publication/1865",
+"https://webstore.iec.ch/publication/20072",
+"https://webstore.iec.ch/publication/6008",
+"https://webstore.iec.ch/publication/20074",
+"https://webstore.iec.ch/publication/6011",
+"https://webstore.iec.ch/publication/6011",
+"https://webstore.iec.ch/publication/20077",
+"https://webstore.iec.ch/publication/20078",
+"https://webstore.iec.ch/publication/6015",
+"https://webstore.iec.ch/publication/20079",
+"https://webstore.iec.ch/publication/6016",
+"https://webstore.iec.ch/publication/6019",
+"https://webstore.iec.ch/publication/20080",
+"https://webstore.iec.ch/publication/6017",
+"https://webstore.iec.ch/publication/6202",
+"https://webstore.iec.ch/publication/27527",
+"https://webstore.iec.ch/publication/6203",
+"https://webstore.iec.ch/publication/64397",
+"https://webstore.iec.ch/publication/22834",
+"https://webstore.iec.ch/publication/22537",
+"https://webstore.iec.ch/publication/20183",
+"https://webstore.iec.ch/publication/6204",
+"https://webstore.iec.ch/publication/6208",
+"https://webstore.iec.ch/publication/20189",
+"https://webstore.iec.ch/publication/20190",
+"https://webstore.iec.ch/publication/20191",
+"https://webstore.iec.ch/publication/20192",
+"https://webstore.iec.ch/publication/6210",
+"https://webstore.iec.ch/publication/31356",
+"https://webstore.iec.ch/publication/59669",
+"https://webstore.iec.ch/publication/6212",
+"https://webstore.iec.ch/publication/22090",
+"https://webstore.iec.ch/publication/30444",
+"https://webstore.iec.ch/publication/9602",
+"https://webstore.iec.ch/publication/10255",
+"https://webstore.iec.ch/publication/11302",
+"https://webstore.iec.ch/publication/11304",
+"https://webstore.iec.ch/publication/11314",
+"https://webstore.iec.ch/publication/11322",
+"https://webstore.iec.ch/publication/23118",
+"https://webstore.iec.ch/publication/22636",
+"https://webstore.iec.ch/publication/23481",
+"https://webstore.iec.ch/publication/22637",
+"https://webstore.iec.ch/publication/25315"];
+
+var results = [];
+var entity ;
+
+
+
+function getClass(value) {
+		
+	if (value.includes("Standard")) return "sto:Standard" ;
+	
+	throw "no class found for entry " + value ;
+	
+}
+
+
+function getDate(value) {
+	
+	return "\"" + value + "\"^^xsd:date" ;
+
+}
+
+
+function getLanguage(value) {
+	
+	var languages = value.split("/") ;
+	var counter;
+	var result = "";
+	for (counter = 0; counter < languages.length; counter++) {
+		if (languages[counter].includes("German")) result += "<http://lexvo.org/id/iso639-3/deu>, " ;
+		if (languages[counter].includes("English")) result += "<http://lexvo.org/id/iso639-3/eng>, " ;
+		if (languages[counter].includes("French")) result += "<http://lexvo.org/id/iso639-3/fra>, " ;
+		if (languages[counter].includes("rus")) result += "<http://lexvo.org/id/iso639-3/rus>, " ;
+		if (languages[counter].includes("Spanish")) result += "<http://lexvo.org/id/iso639-3/spa>, " ;
+	}
+	
+	return result ;
+}
+	
+
+function getPropertyValuePair(key, value) {
+	
+	if (key == "Publication type") return "rdf:type" + " " + getClass(value);
+	if (key == "Publication date") return "sto:hasPublicationDate" + " " + getDate(value);
+	if (key == "Edition") return "sto:hasEdition"  + " " + "\"" + value + "\"";
+	if (key.includes("language")) return "sto:hasAvailableLanguage"  + " " + getLanguage(value);
+	if (key == "Technical Committee") return "sto:hasTechnicalCommittee"  + " " + "\"" + value + "\"";
+	if (key == "ICS") return "sto:hasICS"  + " " + "\"" + value + "\"" ;
+	if (key == "Pages") return "sto:hasPages" + " " + "\"" + value + "\"^^xsd:int";
+	if (key == "File size") return "sto:hasFileSize" + " " + "\"" + value + " KB\"";
+	
+	throw "no property found for " + key ;
+}
+
+
+function readInfoTable(url_counter) {
+	
+	var table = ws.document.getElementsByClassName("table-info")[0].children[0] ;
+
+		var i;
+		for (i = 1; i < table.children.length; i++) {
+			var key = table.children[i].children[0].innerHTML ;
+			if (key.startsWith("<")) key = table.children[i].children[0].firstChild.title ;
+			var value = table.children[i].children[1].firstChild.innerHTML ;
+			results[url_counter].push(entity + " " + getPropertyValuePair(key, value ) + " ." ) ;
+		}	
+
+
+}
+
+
+function readHistoryTable(url_counter) {
+	
+	var table = ws.document.getElementsByClassName("table-striped")[0].children[1] ;
+
+	var i;
+	for (i = 0; i < table.children.length; i++) {
+		
+		var key = "sto:" + table.children[i].children[1].firstChild.innerHTML.replace(/\s/g, '_'); ;
+		results[url_counter].push(entity + " prov:wasRevisionOf " + key + " .") ;
+		
+		var edition = table.children[i].children[2].innerHTML ;
+		results[url_counter].push(key + " sto:hasEdition \"" + edition + "\"^^xsd:double .") ;
+		
+		var state = table.children[i].children[3].innerHTML ;
+		results[url_counter].push(key + " sto:hasStatus \"" + state + "\"@en .") ;
+	}	
+
+
+}
+
+
+// source: https://stackoverflow.com/questions/21012580/is-it-possible-to-write-data-to-file-using-only-javascript
+function download(strData, strFileName, strMimeType) {
+    var D = document,
+        A = arguments,
+        a = D.createElement("a"),
+        d = A[0],
+        n = A[1],
+        t = A[2] || "text/plain";
+
+    //build download link:
+    a.href = "data:" + strMimeType + "charset=utf-8," + strData;
+
+
+    if (window.MSBlobBuilder) { // IE10
+        var bb = new MSBlobBuilder();
+        bb.append(strData);
+        return navigator.msSaveBlob(bb, strFileName);
+    } /* end if(window.MSBlobBuilder) */
+
+
+
+    if ('download' in a) { //FF20, CH19
+        a.setAttribute("download", n);
+        a.innerHTML = "downloading...";
+        D.body.appendChild(a);
+        setTimeout(function() {
+            var e = D.createEvent("MouseEvents");
+            e.initMouseEvent("click", true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+            a.dispatchEvent(e);
+            D.body.removeChild(a);
+        }, 66);
+        return true;
+    };
+	
+	
+
+    //do iframe dataURL download: (older W3)
+    var f = D.createElement("iframe");
+    D.body.appendChild(f);
+    f.src = "data:" + (A[2] ? A[2] : "application/octet-stream") + (window.btoa ? ";base64" : "") + "," + (window.btoa ? window.btoa : escape)(strData);
+    setTimeout(function() {
+        D.body.removeChild(f);
+    }, 333);
+    return true;
+}
+
+
+
+var ws;
+
+function load(i) {
+	//console.log(urls[i]);
+	console.log(i);
+	ws = window.open(urls[i]);
+	setTimeout(function() {
+		
+		results[i] = [];
+		results[i][0] = urls[i] ;// first field is the link of the website
+		
+		entity = "sto:" + ws.document.getElementById("view:dOCUMENTNAME1").innerHTML.replace(/\s/g, '_');
+		
+		readInfoTable(i) ; 
+		readHistoryTable(i) ;
+		
+	}, 1000);
+}
+
+
+
+function main(iter) {
+	
+		
+	if (iter > 0) {
+		ws.close();
+	}
+	
+	if (iter < urls.length) {
+		load(iter);
+		setTimeout(function() {	main(iter + 1) }, 2000);
+	} else {
+		console.log(results);
+		download(results.toString(), 'crawler-results.txt', 'text/plain');
+	}
+}
+main(0);

--- a/crawler-results.txt
+++ b/crawler-results.txt
@@ -1,0 +1,1183 @@
+#https://webstore.iec.ch/publication/7433
+sto:IEC_TR_62794:2012 sto:hasPublicationDate "2012-11-07"^^xsd:date .
+sto:IEC_TR_62794:2012 sto:hasEdition "1.0" .
+sto:IEC_TR_62794:2012 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_TR_62794:2012 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_TR_62794:2012 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+sto:IEC_TR_62794:2012 sto:hasPages "36"^^xsd:int .
+sto:IEC_TR_62794:2012 sto:hasFileSize "5525 KB" .
+# https://webstore.iec.ch/publication/153
+sto:IEC_60038:2009 sto:hasPublicationDate "2009-06-17"^^xsd:date .
+sto:IEC_60038:2009 sto:hasEdition "7.0" .
+sto:IEC_60038:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60038:2009 sto:hasTechnicalCommittee "TC 8 - System aspects of electrical energy supply" .
+sto:IEC_60038:2009 sto:hasICS "29.020 - Electrical engineering in general" .
+# https://webstore.iec.ch/publication/96
+sto:IEC_60027-6:2006 sto:hasPublicationDate "2006-12-14"^^xsd:date .
+sto:IEC_60027-6:2006 sto:hasEdition "1.0" .
+sto:IEC_60027-6:2006 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60027-6:2006 sto:hasTechnicalCommittee "TC 25 - Quantities and units" .
+sto:IEC_60027-6:2006 sto:hasICS "01.060 - Quantities and units" .
+# https://webstore.iec.ch/publication/587
+sto:IEC_60073:2002 sto:hasPublicationDate "2002-05-22"^^xsd:date .
+sto:IEC_60073:2002 sto:hasEdition "6.0" .
+sto:IEC_60073:2002 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60073:2002 sto:hasTechnicalCommittee "TC 3 - Information structures and elements, identification and marking principles, documentation and graphical symbols" .
+sto:IEC_60073:2002 sto:hasICS "01.070 - Colour coding" .
+# https://webstore.iec.ch/publication/22991
+sto:IEC_60086-1:2015_RLV sto:hasPublicationDate "2015-07-28"^^xsd:date .
+sto:IEC_60086-1:2015_RLV sto:hasEdition "12.0" .
+sto:IEC_60086-1:2015_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_60086-1:2015_RLV sto:hasTechnicalCommittee "TC 35 - Primary cells and batteries" .
+sto:IEC_60086-1:2015_RLV sto:hasICS "29.220.10 - Primary cells and batteries" .
+# https://webstore.iec.ch/publication/1022
+sto:IEC_60204-11:2000 sto:hasPublicationDate "2000-07-31"^^xsd:date .
+sto:IEC_60204-11:2000 sto:hasEdition "1.0" .
+sto:IEC_60204-11:2000 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60204-11:2000 sto:hasTechnicalCommittee "TC 44 - Safety of machinery - Electrotechnical aspects" .
+sto:IEC_60204-11:2000 sto:hasICS "13.110 - Safety of machinery" .
+sto:IEC_60204-11:2000 sto:hasPages "111"^^xsd:int .
+sto:IEC_60204-11:2000 sto:hasFileSize "470 KB" .
+sto:IEC_60204-11:2000 prov:wasRevisionOf sto:IEC_60204-11:2018_RLV .
+sto:IEC_60204-11:2018_RLV sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_60204-11:2018_RLV sto:hasStatus "Valid"@en .
+sto:IEC_60204-11:2000 prov:wasRevisionOf sto:IEC_60204-11:2018 .
+sto:IEC_60204-11:2018 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_60204-11:2018 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/1165
+sto:IEC_60255-149:2013 sto:hasPublicationDate "2013-07-30"^^xsd:date .
+sto:IEC_60255-149:2013 sto:hasEdition "1.0" .
+sto:IEC_60255-149:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60255-149:2013 sto:hasTechnicalCommittee "TC 95 - Measuring relays and protection equipment" .
+sto:IEC_60255-149:2013 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/1166
+sto:IEC_60255-151:2009 sto:hasPublicationDate "2009-08-28"^^xsd:date .
+sto:IEC_60255-151:2009 sto:hasEdition "1.0" .
+sto:IEC_60255-151:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60255-151:2009 sto:hasTechnicalCommittee "TC 95 - Measuring relays and protection equipment" .
+sto:IEC_60255-151:2009 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/1160
+sto:IEC_60255-1:2009 sto:hasPublicationDate "2009-08-18"^^xsd:date .
+sto:IEC_60255-1:2009 sto:hasEdition "1.0" .
+sto:IEC_60255-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60255-1:2009 sto:hasTechnicalCommittee "TC 95 - Measuring relays and protection equipment" .
+sto:IEC_60255-1:2009 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/1172
+sto:IEC_60255-27:2013 sto:hasPublicationDate "2013-10-15"^^xsd:date .
+sto:IEC_60255-27:2013 sto:hasEdition "2.0" .
+sto:IEC_60255-27:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60255-27:2013 sto:hasTechnicalCommittee "TC 95 - Measuring relays and protection equipment" .
+sto:IEC_60255-27:2013 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/1258
+sto:IEC_60286-3:2013 sto:hasPublicationDate "2013-05-17"^^xsd:date .
+sto:IEC_60286-3:2013 sto:hasEdition "5.0" .
+sto:IEC_60286-3:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60286-3:2013 sto:hasTechnicalCommittee "TC 40 - Capacitors and resistors for electronic equipment" .
+sto:IEC_60286-3:2013 sto:hasICS "31.020 - Electronic components in general" .
+# https://webstore.iec.ch/publication/1259
+sto:IEC_60286-4:2013 sto:hasPublicationDate "2013-07-26"^^xsd:date .
+sto:IEC_60286-4:2013 sto:hasEdition "3.0" .
+sto:IEC_60286-4:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60286-4:2013 sto:hasTechnicalCommittee "TC 40 - Capacitors and resistors for electronic equipment" .
+sto:IEC_60286-4:2013 sto:hasICS "31.020 - Electronic components in general" .
+# https://webstore.iec.ch/publication/63037
+sto:IEC_60286-5:2018_RLV sto:hasPublicationDate "2018-04-25"^^xsd:date .
+sto:IEC_60286-5:2018_RLV sto:hasEdition "3.0" .
+sto:IEC_60286-5:2018_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_60286-5:2018_RLV sto:hasTechnicalCommittee "TC 40 - Capacitors and resistors for electronic equipment" .
+sto:IEC_60286-5:2018_RLV sto:hasICS "31.020 - Electronic components in general" .
+# https://webstore.iec.ch/publication/1949
+sto:IEC_60381-2:1978 sto:hasPublicationDate "1978-01-01"^^xsd:date .
+sto:IEC_60381-2:1978 sto:hasEdition "1.0" .
+sto:IEC_60381-2:1978 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60381-2:1978 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_60381-2:1978 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/1948
+sto:IEC_60381-1:1982 sto:hasPublicationDate "1982-01-01"^^xsd:date .
+sto:IEC_60381-1:1982 sto:hasEdition "2.0" .
+sto:IEC_60381-1:1982 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60381-1:1982 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_60381-1:1982 sto:hasICS "35.240.50 - IT applications in industry" .
+# https://webstore.iec.ch/publication/1950
+sto:IEC_60382:1991 sto:hasPublicationDate "1991-11-01"^^xsd:date .
+sto:IEC_60382:1991 sto:hasEdition "2.0" .
+sto:IEC_60382:1991 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60382:1991 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_60382:1991 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/1950
+sto:IEC_60382:1991 sto:hasPublicationDate "1991-11-01"^^xsd:date .
+sto:IEC_60382:1991 sto:hasEdition "2.0" .
+sto:IEC_60382:1991 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60382:1991 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_60382:1991 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/24120
+sto:IEC_60839-5-2:2016 sto:hasPublicationDate "2016-02-03"^^xsd:date .
+sto:IEC_60839-5-2:2016 sto:hasEdition "2.0" .
+sto:IEC_60839-5-2:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-5-2:2016 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-5-2:2016 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3666
+sto:IEC_60839-7-1:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-1:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-1:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-1:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-1:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3669
+sto:IEC_60839-7-2:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-2:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-2:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-2:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-2:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3671
+sto:IEC_60839-7-3:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-3:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-3:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-3:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-3:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3672
+sto:IEC_60839-7-4:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-4:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-4:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-4:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-4:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3673
+sto:IEC_60839-7-5:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-5:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-5:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-5:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-5:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3674
+sto:IEC_60839-7-6:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-6:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-6:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-6:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-6:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3675
+sto:IEC_60839-7-7:2001 sto:hasPublicationDate "2001-03-09"^^xsd:date .
+sto:IEC_60839-7-7:2001 sto:hasEdition "1.0" .
+sto:IEC_60839-7-7:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60839-7-7:2001 sto:hasTechnicalCommittee "TC 79 - Alarm and electronic security systems" .
+sto:IEC_60839-7-7:2001 sto:hasICS "13.320 - Alarm and warning systems" .
+# https://webstore.iec.ch/publication/3684
+sto:IEC_60848:2013 sto:hasPublicationDate "2013-02-27"^^xsd:date .
+sto:IEC_60848:2013 sto:hasEdition "3.0" .
+sto:IEC_60848:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60848:2013 sto:hasTechnicalCommittee "TC 3 - Information structures and elements, identification and marking principles, documentation and graphical symbols" .
+sto:IEC_60848:2013 sto:hasICS "29.020 - Electrical engineering in general" .
+# https://webstore.iec.ch/publication/3727
+sto:IEC_60864-1:1986 sto:hasPublicationDate "1986-01-01"^^xsd:date .
+sto:IEC_60864-1:1986 sto:hasEdition "1.0" .
+sto:IEC_60864-1:1986 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60864-1:1986 sto:hasTechnicalCommittee "TC 103 - Transmitting equipment for radiocommunication" .
+sto:IEC_60864-1:1986 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3728
+sto:IEC_60864-2:1997 sto:hasPublicationDate "1997-06-17"^^xsd:date .
+sto:IEC_60864-2:1997 sto:hasEdition "1.0" .
+sto:IEC_60864-2:1997 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60864-2:1997 sto:hasTechnicalCommittee "TC 103 - Transmitting equipment for radiocommunication" .
+sto:IEC_60864-2:1997 sto:hasICS "33.060.20 - Receiving and transmitting equipment" .
+# https://webstore.iec.ch/publication/3738
+sto:IEC_60870-2-1:1995 sto:hasPublicationDate "1995-12-08"^^xsd:date .
+sto:IEC_60870-2-1:1995 sto:hasEdition "2.0" .
+sto:IEC_60870-2-1:1995 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60870-2-1:1995 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-2-1:1995 sto:hasICS "29.020 - Electrical engineering in general" .
+# https://webstore.iec.ch/publication/3739
+sto:IEC_60870-2-2:1996 sto:hasPublicationDate "1996-08-19"^^xsd:date .
+sto:IEC_60870-2-2:1996 sto:hasEdition "1.0" .
+sto:IEC_60870-2-2:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_60870-2-2:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-2-2:1996 sto:hasICS "29.020 - Electrical engineering in general" .
+# https://webstore.iec.ch/publication/23822
+sto:IEC_60870-5-101:2003+AMD1:2015_CSV sto:hasPublicationDate "2015-11-26"^^xsd:date .
+sto:IEC_60870-5-101:2003+AMD1:2015_CSV sto:hasEdition "2.1" .
+sto:IEC_60870-5-101:2003+AMD1:2015_CSV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_60870-5-101:2003+AMD1:2015_CSV sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-101:2003+AMD1:2015_CSV sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3744
+sto:IEC_60870-5-102:1996 sto:hasPublicationDate "1996-06-18"^^xsd:date .
+sto:IEC_60870-5-102:1996 sto:hasEdition "1.0" .
+sto:IEC_60870-5-102:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-102:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-102:1996 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3745
+sto:IEC_60870-5-103:1997 sto:hasPublicationDate "1997-12-11"^^xsd:date .
+sto:IEC_60870-5-103:1997 sto:hasEdition "1.0" .
+sto:IEC_60870-5-103:1997 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-103:1997 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-103:1997 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/25035
+sto:IEC_60870-5-104:2006+AMD1:2016_CSV sto:hasPublicationDate "2016-06-07"^^xsd:date .
+sto:IEC_60870-5-104:2006+AMD1:2016_CSV sto:hasEdition "2.1" .
+sto:IEC_60870-5-104:2006+AMD1:2016_CSV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-104:2006+AMD1:2016_CSV sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-104:2006+AMD1:2016_CSV sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3742
+sto:IEC_60870-5-1:1990 sto:hasPublicationDate "1990-02-01"^^xsd:date .
+sto:IEC_60870-5-1:1990 sto:hasEdition "1.0" .
+sto:IEC_60870-5-1:1990 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-1:1990 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-1:1990 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3747
+sto:IEC_60870-5-2:1992 sto:hasPublicationDate "1992-04-30"^^xsd:date .
+sto:IEC_60870-5-2:1992 sto:hasEdition "1.0" .
+sto:IEC_60870-5-2:1992 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-2:1992 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-2:1992 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3748
+sto:IEC_60870-5-3:1992 sto:hasPublicationDate "1992-09-29"^^xsd:date .
+sto:IEC_60870-5-3:1992 sto:hasEdition "1.0" .
+sto:IEC_60870-5-3:1992 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-3:1992 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-3:1992 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3749
+sto:IEC_60870-5-4:1993 sto:hasPublicationDate "1993-08-06"^^xsd:date .
+sto:IEC_60870-5-4:1993 sto:hasEdition "1.0" .
+sto:IEC_60870-5-4:1993 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-4:1993 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-4:1993 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3750
+sto:IEC_60870-5-5:1995 sto:hasPublicationDate "1995-06-04"^^xsd:date .
+sto:IEC_60870-5-5:1995 sto:hasEdition "1.0" .
+sto:IEC_60870-5-5:1995 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-5:1995 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-5:1995 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3751
+sto:IEC_60870-5-6:2006 sto:hasPublicationDate "2006-03-08"^^xsd:date .
+sto:IEC_60870-5-6:2006 sto:hasEdition "1.0" .
+sto:IEC_60870-5-6:2006 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-5-6:2006 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-5-6:2006 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3757
+sto:IEC_60870-6-2:1995 sto:hasPublicationDate "1995-10-31"^^xsd:date .
+sto:IEC_60870-6-2:1995 sto:hasEdition "1.0" .
+sto:IEC_60870-6-2:1995 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-2:1995 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-2:1995 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3758
+sto:IEC_60870-6-501:1995 sto:hasPublicationDate "1995-12-18"^^xsd:date .
+sto:IEC_60870-6-501:1995 sto:hasEdition "1.0" .
+sto:IEC_60870-6-501:1995 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-501:1995 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-501:1995 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3759
+sto:IEC_60870-6-502:1995 sto:hasPublicationDate "1995-12-05"^^xsd:date .
+sto:IEC_60870-6-502:1995 sto:hasEdition "1.0" .
+sto:IEC_60870-6-502:1995 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-502:1995 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-502:1995 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3760
+sto:IEC_60870-6-503:2014 sto:hasPublicationDate "2014-07-15"^^xsd:date .
+sto:IEC_60870-6-503:2014 sto:hasEdition "3.0" .
+sto:IEC_60870-6-503:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-503:2014 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-503:2014 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3765
+sto:IEC_60870-6-601:1994 sto:hasPublicationDate "1994-12-21"^^xsd:date .
+sto:IEC_60870-6-601:1994 sto:hasEdition "1.0" .
+sto:IEC_60870-6-601:1994 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-601:1994 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-601:1994 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3767
+sto:IEC_60870-6-701:1998 sto:hasPublicationDate "1998-08-07"^^xsd:date .
+sto:IEC_60870-6-701:1998 sto:hasEdition "1.0" .
+sto:IEC_60870-6-701:1998 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-701:1998 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-701:1998 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3768
+sto:IEC_60870-6-702:2014 sto:hasPublicationDate "2014-07-15"^^xsd:date .
+sto:IEC_60870-6-702:2014 sto:hasEdition "2.0" .
+sto:IEC_60870-6-702:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-702:2014 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-702:2014 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3769
+sto:IEC_60870-6-802:2014 sto:hasPublicationDate "2014-07-15"^^xsd:date .
+sto:IEC_60870-6-802:2014 sto:hasEdition "3.0" .
+sto:IEC_60870-6-802:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60870-6-802:2014 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_60870-6-802:2014 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/3881
+sto:IEC_60904:2019_SER sto:hasPublicationDate "2019-02-18"^^xsd:date .
+sto:IEC_60904:2019_SER sto:hasEdition "1.0" .
+sto:IEC_60904:2019_SER sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60904:2019_SER sto:hasTechnicalCommittee "TC 82 - Solar photovoltaic energy systems" .
+sto:IEC_60904:2019_SER sto:hasICS "27.160 - Solar energy engineering" .
+sto:IEC_60904:2019_SER sto:hasPages "586"^^xsd:int .
+sto:IEC_60904:2019_SER sto:hasFileSize "16083 KB" .
+# https://webstore.iec.ch/publication/3961
+sto:IEC_60946:1988 sto:hasPublicationDate "1988-09-29"^^xsd:date .
+sto:IEC_60946:1988 sto:hasEdition "1.0" .
+sto:IEC_60946:1988 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60946:1988 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_60946:1988 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/25629
+sto:IEC_61000-6-2:2016_RLV sto:hasPublicationDate "2016-08-10"^^xsd:date .
+sto:IEC_61000-6-2:2016_RLV sto:hasEdition "3.0" .
+sto:IEC_61000-6-2:2016_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61000-6-2:2016_RLV sto:hasTechnicalCommittee "TC 77 - Electromagnetic compatibility" .
+sto:IEC_61000-6-2:2016_RLV sto:hasICS "33.100.20 - Immunity" .
+# https://webstore.iec.ch/publication/25400
+sto:IEC_61010-2-012:2016 sto:hasPublicationDate "2016-07-12"^^xsd:date .
+sto:IEC_61010-2-012:2016 sto:hasEdition "1.0" .
+sto:IEC_61010-2-012:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61010-2-012:2016 sto:hasTechnicalCommittee "TC 66 - Safety of measuring, control and laboratory equipment" .
+sto:IEC_61010-2-012:2016 sto:hasICS "19.080 - Electrical and electronic testing" .
+# https://webstore.iec.ch/publication/60204
+sto:IEC_61010-2-201:2017_RLV sto:hasPublicationDate "2017-03-24"^^xsd:date .
+sto:IEC_61010-2-201:2017_RLV sto:hasEdition "2.0" .
+sto:IEC_61010-2-201:2017_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61010-2-201:2017_RLV sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_61010-2-201:2017_RLV sto:hasICS "17.020 - Metrology and measurement in general" .
+# https://webstore.iec.ch/publication/25399
+sto:IEC_61010-2-202:2016 sto:hasPublicationDate "2016-07-12"^^xsd:date .
+sto:IEC_61010-2-202:2016 sto:hasEdition "1.0" .
+sto:IEC_61010-2-202:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61010-2-202:2016 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_61010-2-202:2016 sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/4550
+sto:IEC_61131-1:2003 sto:hasPublicationDate "2003-05-22"^^xsd:date .
+sto:IEC_61131-1:2003 sto:hasEdition "2.0" .
+sto:IEC_61131-1:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61131-1:2003 sto:hasTechnicalCommittee "TC 65/SC 65B - Measurement and control devices" .
+sto:IEC_61131-1:2003 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/4550
+sto:IEC_61131-1:2003 sto:hasPublicationDate "2003-05-22"^^xsd:date .
+sto:IEC_61131-1:2003 sto:hasEdition "2.0" .
+sto:IEC_61131-1:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61131-1:2003 sto:hasTechnicalCommittee "TC 65/SC 65B - Measurement and control devices" .
+sto:IEC_61131-1:2003 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/4707
+sto:IEC_61160:2005 sto:hasPublicationDate "2005-09-27"^^xsd:date .
+sto:IEC_61160:2005 sto:hasEdition "2.0" .
+sto:IEC_61160:2005 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61160:2005 sto:hasTechnicalCommittee "TC 56 - Dependability" .
+sto:IEC_61160:2005 sto:hasICS "03.120.01 - Quality in general" .
+# https://webstore.iec.ch/publication/5263
+sto:IEC_61310-1:2007 sto:hasPublicationDate "2007-02-16"^^xsd:date .
+sto:IEC_61310-1:2007 sto:hasEdition "2.0" .
+sto:IEC_61310-1:2007 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61310-1:2007 sto:hasTechnicalCommittee "TC 44 - Safety of machinery - Electrotechnical aspects" .
+sto:IEC_61310-1:2007 sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/5264
+sto:IEC_61310-2:2007 sto:hasPublicationDate "2007-02-16"^^xsd:date .
+sto:IEC_61310-2:2007 sto:hasEdition "2.0" .
+sto:IEC_61310-2:2007 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61310-2:2007 sto:hasTechnicalCommittee "TC 44 - Safety of machinery - Electrotechnical aspects" .
+sto:IEC_61310-2:2007 sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/5265
+sto:IEC_61310-3:2007 sto:hasPublicationDate "2007-02-16"^^xsd:date .
+sto:IEC_61310-3:2007 sto:hasEdition "2.0" .
+sto:IEC_61310-3:2007 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61310-3:2007 sto:hasTechnicalCommittee "TC 44 - Safety of machinery - Electrotechnical aspects" .
+sto:IEC_61310-3:2007 sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/5308
+sto:IEC_61334-5-1:2001 sto:hasPublicationDate "2001-05-28"^^xsd:date .
+sto:IEC_61334-5-1:2001 sto:hasEdition "2.0" .
+sto:IEC_61334-5-1:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-5-1:2001 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-5-1:2001 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/5308
+sto:IEC_61334-5-1:2001 sto:hasPublicationDate "2001-05-28"^^xsd:date .
+sto:IEC_61334-5-1:2001 sto:hasEdition "2.0" .
+sto:IEC_61334-5-1:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-5-1:2001 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-5-1:2001 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/5297
+sto:IEC_61334-3-1:1998 sto:hasPublicationDate "1998-11-24"^^xsd:date .
+sto:IEC_61334-3-1:1998 sto:hasEdition "1.0" .
+sto:IEC_61334-3-1:1998 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-3-1:1998 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-3-1:1998 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5298
+sto:IEC_61334-3-21:1996 sto:hasPublicationDate "1996-03-27"^^xsd:date .
+sto:IEC_61334-3-21:1996 sto:hasEdition "1.0" .
+sto:IEC_61334-3-21:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-3-21:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-3-21:1996 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5299
+sto:IEC_61334-3-22:2001 sto:hasPublicationDate "2001-01-12"^^xsd:date .
+sto:IEC_61334-3-22:2001 sto:hasEdition "1.0" .
+sto:IEC_61334-3-22:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-3-22:2001 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-3-22:2001 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5300
+sto:IEC_61334-4-1:1996 sto:hasPublicationDate "1996-07-31"^^xsd:date .
+sto:IEC_61334-4-1:1996 sto:hasEdition "1.0" .
+sto:IEC_61334-4-1:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-1:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-1:1996 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5301
+sto:IEC_61334-4-32:1996 sto:hasPublicationDate "1996-09-26"^^xsd:date .
+sto:IEC_61334-4-32:1996 sto:hasEdition "1.0" .
+sto:IEC_61334-4-32:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-32:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-32:1996 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5302
+sto:IEC_61334-4-33:1998 sto:hasPublicationDate "1998-07-10"^^xsd:date .
+sto:IEC_61334-4-33:1998 sto:hasEdition "1.0" .
+sto:IEC_61334-4-33:1998 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-33:1998 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-33:1998 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5303
+sto:IEC_61334-4-41:1996 sto:hasPublicationDate "1996-08-13"^^xsd:date .
+sto:IEC_61334-4-41:1996 sto:hasEdition "1.0" .
+sto:IEC_61334-4-41:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-41:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-41:1996 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5304
+sto:IEC_61334-4-42:1996 sto:hasPublicationDate "1996-10-09"^^xsd:date .
+sto:IEC_61334-4-42:1996 sto:hasEdition "1.0" .
+sto:IEC_61334-4-42:1996 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-42:1996 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-42:1996 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5305
+sto:IEC_61334-4-511:2000 sto:hasPublicationDate "2000-04-18"^^xsd:date .
+sto:IEC_61334-4-511:2000 sto:hasEdition "1.0" .
+sto:IEC_61334-4-511:2000 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-511:2000 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-511:2000 sto:hasICS "33.040.40 - Data communication networks" .
+# https://webstore.iec.ch/publication/5306
+sto:IEC_61334-4-512:2001 sto:hasPublicationDate "2001-10-30"^^xsd:date .
+sto:IEC_61334-4-512:2001 sto:hasEdition "1.0" .
+sto:IEC_61334-4-512:2001 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-512:2001 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-512:2001 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/5307
+sto:IEC_61334-4-61:1998 sto:hasPublicationDate "1998-07-10"^^xsd:date .
+sto:IEC_61334-4-61:1998 sto:hasEdition "1.0" .
+sto:IEC_61334-4-61:1998 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-4-61:1998 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-4-61:1998 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5313
+sto:IEC_61334-6:2000 sto:hasPublicationDate "2000-06-16"^^xsd:date .
+sto:IEC_61334-6:2000 sto:hasEdition "1.0" .
+sto:IEC_61334-6:2000 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61334-6:2000 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61334-6:2000 sto:hasICS "29.240.20 - Power transmission and distribution lines" .
+# https://webstore.iec.ch/publication/5380
+sto:IEC_61360-1:2009 sto:hasPublicationDate "2009-07-30"^^xsd:date .
+sto:IEC_61360-1:2009 sto:hasEdition "3.0" .
+sto:IEC_61360-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61360-1:2009 sto:hasTechnicalCommittee "TC 3/SC 3D - Product properties and classes and their identification" .
+sto:IEC_61360-1:2009 sto:hasICS "31.020 - Electronic components in general" .
+sto:IEC_61360-1:2009 sto:hasPages "176"^^xsd:int .
+sto:IEC_61360-1:2009 sto:hasFileSize "2075 KB" .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2017 .
+sto:IEC_61360-1:2017 sto:hasEdition "4.0"^^xsd:double .
+sto:IEC_61360-1:2017 sto:hasStatus "Valid"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002+AMD1:2003_CSV .
+sto:IEC_61360-1:2002+AMD1:2003_CSV sto:hasEdition "2.1"^^xsd:double .
+sto:IEC_61360-1:2002+AMD1:2003_CSV sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002/AMD1:2003 .
+sto:IEC_61360-1:2002/AMD1:2003 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61360-1:2002/AMD1:2003 sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002 .
+sto:IEC_61360-1:2002 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61360-1:2002 sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:1995 .
+sto:IEC_61360-1:1995 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_61360-1:1995 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/26603
+sto:IEC_61400-12-1:2017 sto:hasPublicationDate "2017-03-03"^^xsd:date .
+sto:IEC_61400-12-1:2017 sto:hasEdition "2.0" .
+sto:IEC_61400-12-1:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61400-12-1:2017 sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-12-1:2017 sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/61087
+sto:IEC_61400-25-1:2017_RLV sto:hasPublicationDate "2017-07-20"^^xsd:date .
+sto:IEC_61400-25-1:2017_RLV sto:hasEdition "2.0" .
+sto:IEC_61400-25-1:2017_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61400-25-1:2017_RLV sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-1:2017_RLV sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/22813
+sto:IEC_61400-25-2:2015 sto:hasPublicationDate "2015-06-30"^^xsd:date .
+sto:IEC_61400-25-2:2015 sto:hasEdition "2.0" .
+sto:IEC_61400-25-2:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61400-25-2:2015 sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-2:2015 sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/22808
+sto:IEC_61400-25-3:2015_RLV sto:hasPublicationDate "2015-06-30"^^xsd:date .
+sto:IEC_61400-25-3:2015_RLV sto:hasEdition "2.0" .
+sto:IEC_61400-25-3:2015_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61400-25-3:2015_RLV sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-3:2015_RLV sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/59497
+sto:IEC_61400-25-4:2016_RLV sto:hasPublicationDate "2016-11-30"^^xsd:date .
+sto:IEC_61400-25-4:2016_RLV sto:hasEdition "2.0" .
+sto:IEC_61400-25-4:2016_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61400-25-4:2016_RLV sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-4:2016_RLV sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/26560
+sto:IEC_61400-25-5:2017 sto:hasPublicationDate "2017-09-20"^^xsd:date .
+sto:IEC_61400-25-5:2017 sto:hasEdition "2.0" .
+sto:IEC_61400-25-5:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61400-25-5:2017 sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-5:2017 sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/32580
+sto:IEC_61400-25-6:2016 sto:hasPublicationDate "2016-12-16"^^xsd:date .
+sto:IEC_61400-25-6:2016 sto:hasEdition "2.0" .
+sto:IEC_61400-25-6:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61400-25-6:2016 sto:hasTechnicalCommittee "TC 88 - Wind energy generation systems" .
+sto:IEC_61400-25-6:2016 sto:hasICS "27.180 - Wind turbine energy systems" .
+# https://webstore.iec.ch/publication/5506
+sto:IEC_61499-1:2012 sto:hasPublicationDate "2012-11-07"^^xsd:date .
+sto:IEC_61499-1:2012 sto:hasEdition "2.0" .
+sto:IEC_61499-1:2012 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61499-1:2012 sto:hasTechnicalCommittee "TC 65/SC 65B - Measurement and control devices" .
+sto:IEC_61499-1:2012 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/5513
+sto:IEC_61506:1997 sto:hasPublicationDate "1997-02-28"^^xsd:date .
+sto:IEC_61506:1997 sto:hasEdition "1.0" .
+sto:IEC_61506:1997 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61506:1997 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_61506:1997 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/24241
+sto:IEC_61511-1:2016 sto:hasPublicationDate "2016-02-24"^^xsd:date .
+sto:IEC_61511-1:2016 sto:hasEdition "2.0" .
+sto:IEC_61511-1:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61511-1:2016 sto:hasTechnicalCommittee "TC 65/SC 65A - System aspects" .
+sto:IEC_61511-1:2016 sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/5528
+sto:IEC_61512-1:1997 sto:hasPublicationDate "1997-08-26"^^xsd:date .
+sto:IEC_61512-1:1997 sto:hasEdition "1.0" .
+sto:IEC_61512-1:1997 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61512-1:1997 sto:hasTechnicalCommittee "TC 65/SC 65A - System aspects" .
+sto:IEC_61512-1:1997 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/5532
+sto:IEC_61513:2011 sto:hasPublicationDate "2011-08-25"^^xsd:date .
+sto:IEC_61513:2011 sto:hasEdition "2.0" .
+sto:IEC_61513:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61513:2011 sto:hasTechnicalCommittee "TC 45/SC 45A - Instrumentation, control and electrical power systems of nuclear facilities" .
+sto:IEC_61513:2011 sto:hasICS "27.120.20 - Nuclear power plants. Safety" .
+# https://webstore.iec.ch/publication/5723
+sto:IEC_61690-1:2000 sto:hasPublicationDate "2000-01-31"^^xsd:date .
+sto:IEC_61690-1:2000 sto:hasEdition "1.0" .
+sto:IEC_61690-1:2000 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61690-1:2000 sto:hasTechnicalCommittee "TC 91 - Electronics assembly technology" .
+sto:IEC_61690-1:2000 sto:hasICS "35.240.50 - IT applications in industry" .
+# https://webstore.iec.ch/publication/5724
+sto:IEC_61690-2:2000 sto:hasPublicationDate "2000-01-31"^^xsd:date .
+sto:IEC_61690-2:2000 sto:hasEdition "1.0" .
+sto:IEC_61690-2:2000 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61690-2:2000 sto:hasTechnicalCommittee "TC 91 - Electronics assembly technology" .
+sto:IEC_61690-2:2000 sto:hasICS "35.240.50 - IT applications in industry" .
+# https://webstore.iec.ch/publication/5726
+sto:IEC_61691-6:2009 sto:hasPublicationDate "2009-12-14"^^xsd:date .
+sto:IEC_61691-6:2009 sto:hasEdition "1.0" .
+sto:IEC_61691-6:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61691-6:2009 sto:hasTechnicalCommittee "TC 91 - Electronics assembly technology" .
+sto:IEC_61691-6:2009 sto:hasICS "25.040.01 - Industrial automation systems in general" .
+# https://webstore.iec.ch/publication/5878
+sto:IEC_61784-1:2014 sto:hasPublicationDate "2014-08-19"^^xsd:date .
+sto:IEC_61784-1:2014 sto:hasEdition "4.0" .
+sto:IEC_61784-1:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61784-1:2014 sto:hasTechnicalCommittee "TC 65/SC 65C - Industrial networks" .
+sto:IEC_61784-1:2014 sto:hasICS "35.100.20 - Data link layer" .
+# https://webstore.iec.ch/publication/5953
+sto:IEC_TS_61804-1:2003 sto:hasPublicationDate "2003-10-09"^^xsd:date .
+# https://webstore.iec.ch/publication/33869
+sto:IEC_61810-2:2017 sto:hasPublicationDate "2017-05-30"^^xsd:date .
+sto:IEC_61810-2:2017 sto:hasEdition "3.0" .
+sto:IEC_61810-2:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61810-2:2017 sto:hasTechnicalCommittee "TC 94 - All-or-nothing electrical relays" .
+sto:IEC_61810-2:2017 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/5963
+sto:IEC_61810-7:2006 sto:hasPublicationDate "2006-03-14"^^xsd:date .
+sto:IEC_61810-7:2006 sto:hasEdition "2.0" .
+sto:IEC_61810-7:2006 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_61810-7:2006 sto:hasTechnicalCommittee "TC 94 - All-or-nothing electrical relays" .
+sto:IEC_61810-7:2006 sto:hasICS "29.120.70 - Relays" .
+# https://webstore.iec.ch/publication/6225
+sto:IEC_61987-1:2006 sto:hasPublicationDate "2006-12-14"^^xsd:date .
+sto:IEC_61987-1:2006 sto:hasEdition "1.0" .
+sto:IEC_61987-1:2006 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61987-1:2006 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_61987-1:2006 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/22797
+sto:IEC_62061:2005+AMD1:2012+AMD2:2015_CSV sto:hasPublicationDate "2015-06-26"^^xsd:date .
+sto:IEC_62061:2005+AMD1:2012+AMD2:2015_CSV sto:hasEdition "1.2" .
+sto:IEC_62061:2005+AMD1:2012+AMD2:2015_CSV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62061:2005+AMD1:2012+AMD2:2015_CSV sto:hasTechnicalCommittee "TC 44 - Safety of machinery - Electrotechnical aspects" .
+sto:IEC_62061:2005+AMD1:2012+AMD2:2015_CSV sto:hasICS "13.110 - Safety of machinery" .
+# https://webstore.iec.ch/publication/6675
+sto:IEC_62264-1:2013 sto:hasPublicationDate "2013-05-22"^^xsd:date .
+sto:IEC_62264-1:2013 sto:hasEdition "2.0" .
+sto:IEC_62264-1:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62264-1:2013 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_62264-1:2013 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/22781
+sto:IEC_62279:2015 sto:hasPublicationDate "2015-06-25"^^xsd:date .
+sto:IEC_62279:2015 sto:hasEdition "2.0" .
+sto:IEC_62279:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62279:2015 sto:hasTechnicalCommittee "TC 9 - Electrical equipment and systems for railways" .
+sto:IEC_62279:2015 sto:hasICS "45.060.01 - Railway rolling stock in general" .
+# https://webstore.iec.ch/publication/6871
+sto:IEC_62337:2012 sto:hasPublicationDate "2012-02-22"^^xsd:date .
+sto:IEC_62337:2012 sto:hasEdition "2.0" .
+sto:IEC_62337:2012 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62337:2012 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_62337:2012 sto:hasICS "91.010.20 - Contractual aspects" .
+# https://webstore.iec.ch/publication/25442
+sto:IEC_62424:2016 sto:hasPublicationDate "2016-07-15"^^xsd:date .
+sto:IEC_62424:2016 sto:hasEdition "2.0" .
+sto:IEC_62424:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62424:2016 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_62424:2016 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/7029
+sto:IEC_TS_62443-1-1:2009 sto:hasPublicationDate "2009-07-30"^^xsd:date .
+sto:IEC_TS_62443-1-1:2009 sto:hasEdition "1.0" .
+sto:IEC_TS_62443-1-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_TS_62443-1-1:2009 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_TS_62443-1-1:2009 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/7033
+sto:IEC_62443-3-3:2013 sto:hasPublicationDate "2013-08-07"^^xsd:date .
+sto:IEC_62443-3-3:2013 sto:hasEdition "1.0" .
+sto:IEC_62443-3-3:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62443-3-3:2013 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_62443-3-3:2013 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/7040
+sto:IEC_62453-1:2009 sto:hasPublicationDate "2009-06-30"^^xsd:date .
+sto:IEC_62453-1:2009 sto:hasEdition "1.0" .
+sto:IEC_62453-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62453-1:2009 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_62453-1:2009 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+sto:IEC_62453-1:2009 sto:hasPages "86"^^xsd:int .
+sto:IEC_62453-1:2009 sto:hasFileSize "2963 KB" .
+sto:IEC_62453-1:2009 prov:wasRevisionOf sto:IEC_62453-1:2016 .
+sto:IEC_62453-1:2016 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_62453-1:2016 sto:hasStatus "Valid"@en .
+sto:IEC_62453-1:2009 prov:wasRevisionOf sto:IEC_PAS_62453-1:2006 .
+sto:IEC_PAS_62453-1:2006 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_PAS_62453-1:2006 sto:hasStatus "Replaced"@en .
+# https://webstore.iec.ch/publication/24433
+sto:IEC_62591:2016 sto:hasPublicationDate "2016-03-30"^^xsd:date .
+sto:IEC_62591:2016 sto:hasEdition "2.0" .
+sto:IEC_62591:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62591:2016 sto:hasTechnicalCommittee "TC 65/SC 65C - Industrial networks" .
+sto:IEC_62591:2016 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/24433
+sto:IEC_62591:2016 sto:hasPublicationDate "2016-03-30"^^xsd:date .
+sto:IEC_62591:2016 sto:hasEdition "2.0" .
+sto:IEC_62591:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62591:2016 sto:hasTechnicalCommittee "TC 65/SC 65C - Industrial networks" .
+sto:IEC_62591:2016 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/7326
+sto:IEC_62656-1:2014 sto:hasPublicationDate "2014-08-26"^^xsd:date .
+sto:IEC_62656-1:2014 sto:hasEdition "1.0" .
+sto:IEC_62656-1:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_62656-1:2014 sto:hasTechnicalCommittee "TC 3/SC 3D - Product properties and classes and their identification" .
+sto:IEC_62656-1:2014 sto:hasICS "01.040.01 - Generalities. Terminology. Standardization. Documentation (Vocabularies)" .
+# https://webstore.iec.ch/publication/7446
+sto:IEC_TR_62837:2013 sto:hasPublicationDate "2013-09-25"^^xsd:date .
+sto:IEC_TR_62837:2013 sto:hasEdition "1.0" .
+sto:IEC_TR_62837:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_TR_62837:2013 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_TR_62837:2013 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/30082
+sto:IEC_PAS_63088:2017 sto:hasPublicationDate "2017-03-07"^^xsd:date .
+sto:IEC_PAS_63088:2017 sto:hasEdition "1.0" .
+sto:IEC_PAS_63088:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_PAS_63088:2017 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_PAS_63088:2017 sto:hasICS "25.040.01 - Industrial automation systems in general" .
+# https://webstore.iec.ch/publication/6626
+sto:IEC_62237:2003 sto:hasPublicationDate "2003-10-26"^^xsd:date .
+sto:IEC_62237:2003 sto:hasEdition "1.0" .
+sto:IEC_62237:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra>, <http://lexvo.org/id/iso639-3/spa> .
+sto:IEC_62237:2003 sto:hasTechnicalCommittee "TC 78 - Live working" .
+sto:IEC_62237:2003 sto:hasICS "13.260 - Protection against electric shock. Live working" .
+# https://webstore.iec.ch/publication/33023
+sto:IEC_TS_62832-1:2016 sto:hasPublicationDate "2016-12-16"^^xsd:date .
+sto:IEC_TS_62832-1:2016 sto:hasEdition "1.0" .
+sto:IEC_TS_62832-1:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_TS_62832-1:2016 sto:hasTechnicalCommittee "TC 65 - Industrial-process measurement, control and automation" .
+sto:IEC_TS_62832-1:2016 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/5380
+sto:IEC_61360-1:2009 sto:hasPublicationDate "2009-07-30"^^xsd:date .
+sto:IEC_61360-1:2009 sto:hasEdition "3.0" .
+sto:IEC_61360-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61360-1:2009 sto:hasTechnicalCommittee "TC 3/SC 3D - Product properties and classes and their identification" .
+sto:IEC_61360-1:2009 sto:hasICS "31.020 - Electronic components in general" .
+sto:IEC_61360-1:2009 sto:hasPages "176"^^xsd:int .
+sto:IEC_61360-1:2009 sto:hasFileSize "2075 KB" .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2017 .
+sto:IEC_61360-1:2017 sto:hasEdition "4.0"^^xsd:double .
+sto:IEC_61360-1:2017 sto:hasStatus "Valid"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002+AMD1:2003_CSV .
+sto:IEC_61360-1:2002+AMD1:2003_CSV sto:hasEdition "2.1"^^xsd:double .
+sto:IEC_61360-1:2002+AMD1:2003_CSV sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002/AMD1:2003 .
+sto:IEC_61360-1:2002/AMD1:2003 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61360-1:2002/AMD1:2003 sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:2002 .
+sto:IEC_61360-1:2002 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61360-1:2002 sto:hasStatus "Revised"@en .
+sto:IEC_61360-1:2009 prov:wasRevisionOf sto:IEC_61360-1:1995 .
+sto:IEC_61360-1:1995 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_61360-1:1995 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/62997
+sto:ISO/IEC_14443-1:2018 sto:hasPublicationDate "2018-04-12"^^xsd:date .
+sto:ISO/IEC_14443-1:2018 sto:hasEdition "4.0" .
+sto:ISO/IEC_14443-1:2018 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_14443-1:2018 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 17 - Cards and security devices for personal identification" .
+sto:ISO/IEC_14443-1:2018 sto:hasICS "35.240.15 - Identification cards and related devices" .
+sto:ISO/IEC_14443-1:2018 sto:hasPages "11"^^xsd:int .
+sto:ISO/IEC_14443-1:2018 sto:hasFileSize "741 KB" .
+sto:ISO/IEC_14443-1:2018 prov:wasRevisionOf sto:ISO/IEC_14443-1:2016 .
+sto:ISO/IEC_14443-1:2016 sto:hasEdition "3.0"^^xsd:double .
+sto:ISO/IEC_14443-1:2016 sto:hasStatus "Revised"@en .
+sto:ISO/IEC_14443-1:2018 prov:wasRevisionOf sto:ISO/IEC_14443-1:2008/AMD1:2012 .
+sto:ISO/IEC_14443-1:2008/AMD1:2012 sto:hasEdition "2.0"^^xsd:double .
+sto:ISO/IEC_14443-1:2008/AMD1:2012 sto:hasStatus "Revised"@en .
+sto:ISO/IEC_14443-1:2018 prov:wasRevisionOf sto:ISO/IEC_14443-1:2008 .
+sto:ISO/IEC_14443-1:2008 sto:hasEdition "2.0"^^xsd:double .
+sto:ISO/IEC_14443-1:2008 sto:hasStatus "Revised"@en .
+sto:ISO/IEC_14443-1:2018 prov:wasRevisionOf sto:ISO/IEC_14443-1:2000 .
+sto:ISO/IEC_14443-1:2000 sto:hasEdition "1.0"^^xsd:double .
+sto:ISO/IEC_14443-1:2000 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/10334
+sto:ISO/IEC_15459-1:2014 sto:hasPublicationDate "2014-11-12"^^xsd:date .
+sto:ISO/IEC_15459-1:2014 sto:hasEdition "3.0" .
+sto:ISO/IEC_15459-1:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_15459-1:2014 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 31 - Automatic identification and data capture techniques" .
+sto:ISO/IEC_15459-1:2014 sto:hasICS "35.040.50 - Automatic identification and data capture techniques " .
+sto:ISO/IEC_15459-1:2014 sto:hasPages "8"^^xsd:int .
+sto:ISO/IEC_15459-1:2014 sto:hasFileSize "1345 KB" .
+sto:ISO/IEC_15459-1:2014 prov:wasRevisionOf sto:ISO/IEC_15459-1:2006 .
+sto:ISO/IEC_15459-1:2006 sto:hasEdition "2.0"^^xsd:double .
+sto:ISO/IEC_15459-1:2006 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/11190
+sto:ISO/IEC_24760-1:2011 sto:hasPublicationDate "2011-12-07"^^xsd:date .
+sto:ISO/IEC_24760-1:2011 sto:hasEdition "1.0" .
+sto:ISO/IEC_24760-1:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_24760-1:2011 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_24760-1:2011 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_24760-1:2011 sto:hasPages "20"^^xsd:int .
+sto:ISO/IEC_24760-1:2011 sto:hasFileSize "715 KB" .
+sto:ISO/IEC_24760-1:2011 prov:wasRevisionOf sto:ISO/IEC_24760-1:2019 .
+sto:ISO/IEC_24760-1:2019 sto:hasEdition "2.0"^^xsd:double .
+sto:ISO/IEC_24760-1:2019 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/11351
+sto:ISO/IEC_29115:2013 sto:hasPublicationDate "2013-03-27"^^xsd:date .
+sto:ISO/IEC_29115:2013 sto:hasEdition "1.0" .
+sto:ISO/IEC_29115:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_29115:2013 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_29115:2013 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_29115:2013 sto:hasPages "36"^^xsd:int .
+sto:ISO/IEC_29115:2013 sto:hasFileSize "681 KB" .
+# https://webstore.iec.ch/publication/60834
+sto:ISO/IEC_29161:2016 sto:hasPublicationDate "2016-07-28"^^xsd:date .
+sto:ISO/IEC_29161:2016 sto:hasEdition "1.0" .
+sto:ISO/IEC_29161:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_29161:2016 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 31 - Automatic identification and data capture techniques" .
+sto:ISO/IEC_29161:2016 sto:hasICS "35.040.50 - Automatic identification and data capture techniques " .
+sto:ISO/IEC_29161:2016 sto:hasPages "18"^^xsd:int .
+sto:ISO/IEC_29161:2016 sto:hasFileSize "1065 KB" .
+# https://webstore.iec.ch/publication/11411
+sto:ISO/IEC_29182-1:2013 sto:hasPublicationDate "2013-06-03"^^xsd:date .
+sto:ISO/IEC_29182-1:2013 sto:hasEdition "1.0" .
+sto:ISO/IEC_29182-1:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_29182-1:2013 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 41 - Internet of things and related technologies" .
+sto:ISO/IEC_29182-1:2013 sto:hasICS "35.110 - Networking" .
+sto:ISO/IEC_29182-1:2013 sto:hasPages "8"^^xsd:int .
+sto:ISO/IEC_29182-1:2013 sto:hasFileSize "865 KB" .
+# https://webstore.iec.ch/publication/11978
+sto:ISO/IEC/IEEE_42010:2011 sto:hasPublicationDate "2011-11-24"^^xsd:date .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasEdition "1.0" .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 7 - Software and systems engineering" .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasICS "35.080 - Software" .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasPages "37"^^xsd:int .
+sto:ISO/IEC/IEEE_42010:2011 sto:hasFileSize "1978 KB" .
+# https://webstore.iec.ch/publication/1865
+sto:IEC_60364-1:2005 sto:hasPublicationDate "2005-11-29"^^xsd:date .
+sto:IEC_60364-1:2005 sto:hasEdition "5.0" .
+sto:IEC_60364-1:2005 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_60364-1:2005 sto:hasTechnicalCommittee "TC 64 - Electrical installations and protection against electric shock" .
+sto:IEC_60364-1:2005 sto:hasICS "91.140.50 - Electricity supply systems" .
+# https://webstore.iec.ch/publication/20072
+sto:IEC_61850-10:2005 sto:hasPublicationDate "2005-05-30"^^xsd:date .
+sto:IEC_61850-10:2005 sto:hasEdition "1.0" .
+sto:IEC_61850-10:2005 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-10:2005 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-10:2005 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-10:2005 sto:hasPages "43"^^xsd:int .
+sto:IEC_61850-10:2005 sto:hasFileSize "452 KB" .
+sto:IEC_61850-10:2005 prov:wasRevisionOf sto:IEC_61850-10:2012 .
+sto:IEC_61850-10:2012 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61850-10:2012 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/6008
+sto:IEC_61850-10:2012 sto:hasPublicationDate "2012-12-14"^^xsd:date .
+sto:IEC_61850-10:2012 sto:hasEdition "2.0" .
+sto:IEC_61850-10:2012 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-10:2012 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-10:2012 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20074
+sto:IEC_61850-4:2002 sto:hasPublicationDate "2002-01-17"^^xsd:date .
+sto:IEC_61850-4:2002 sto:hasEdition "1.0" .
+sto:IEC_61850-4:2002 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-4:2002 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-4:2002 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-4:2002 sto:hasPages "59"^^xsd:int .
+sto:IEC_61850-4:2002 sto:hasFileSize "444 KB" .
+# https://webstore.iec.ch/publication/6011
+sto:IEC_61850-4:2011 sto:hasPublicationDate "2011-04-11"^^xsd:date .
+sto:IEC_61850-4:2011 sto:hasEdition "2.0" .
+sto:IEC_61850-4:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-4:2011 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-4:2011 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6011
+sto:IEC_61850-4:2011 sto:hasPublicationDate "2011-04-11"^^xsd:date .
+sto:IEC_61850-4:2011 sto:hasEdition "2.0" .
+sto:IEC_61850-4:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-4:2011 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-4:2011 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20077
+sto:IEC_61850-7-1:2003 sto:hasPublicationDate "2003-07-23"^^xsd:date .
+sto:IEC_61850-7-1:2003 sto:hasEdition "1.0" .
+sto:IEC_61850-7-1:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-7-1:2003 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-1:2003 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-7-1:2003 sto:hasPages "110"^^xsd:int .
+sto:IEC_61850-7-1:2003 sto:hasFileSize "4106 KB" .
+# https://webstore.iec.ch/publication/20078
+sto:IEC_61850-7-2:2003 sto:hasPublicationDate "2003-05-12"^^xsd:date .
+sto:IEC_61850-7-2:2003 sto:hasEdition "1.0" .
+sto:IEC_61850-7-2:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-7-2:2003 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-2:2003 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-7-2:2003 sto:hasPages "171"^^xsd:int .
+sto:IEC_61850-7-2:2003 sto:hasFileSize "3596 KB" .
+sto:IEC_61850-7-2:2003 prov:wasRevisionOf sto:IEC_61850-7-2:2010 .
+sto:IEC_61850-7-2:2010 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61850-7-2:2010 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/6015
+sto:IEC_61850-7-2:2010 sto:hasPublicationDate "2010-08-24"^^xsd:date .
+sto:IEC_61850-7-2:2010 sto:hasEdition "2.0" .
+sto:IEC_61850-7-2:2010 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-7-2:2010 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-2:2010 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20079
+sto:IEC_61850-7-3:2003 sto:hasPublicationDate "2003-05-12"^^xsd:date .
+sto:IEC_61850-7-3:2003 sto:hasEdition "1.0" .
+sto:IEC_61850-7-3:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-7-3:2003 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-3:2003 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-7-3:2003 sto:hasPages "64"^^xsd:int .
+sto:IEC_61850-7-3:2003 sto:hasFileSize "3236 KB" .
+sto:IEC_61850-7-3:2003 prov:wasRevisionOf sto:IEC_61850-7-3:2010 .
+sto:IEC_61850-7-3:2010 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61850-7-3:2010 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/6016
+sto:IEC_61850-7-3:2010 sto:hasPublicationDate "2010-12-16"^^xsd:date .
+sto:IEC_61850-7-3:2010 sto:hasEdition "2.0" .
+sto:IEC_61850-7-3:2010 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-7-3:2010 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-3:2010 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6019
+sto:IEC_61850-7-420:2009 sto:hasPublicationDate "2009-03-10"^^xsd:date .
+sto:IEC_61850-7-420:2009 sto:hasEdition "1.0" .
+sto:IEC_61850-7-420:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-7-420:2009 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-420:2009 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20080
+sto:IEC_61850-7-4:2003 sto:hasPublicationDate "2003-05-13"^^xsd:date .
+sto:IEC_61850-7-4:2003 sto:hasEdition "1.0" .
+sto:IEC_61850-7-4:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61850-7-4:2003 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-4:2003 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61850-7-4:2003 sto:hasPages "104"^^xsd:int .
+sto:IEC_61850-7-4:2003 sto:hasFileSize "3475 KB" .
+sto:IEC_61850-7-4:2003 prov:wasRevisionOf sto:IEC_61850-7-4:2010 .
+sto:IEC_61850-7-4:2010 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61850-7-4:2010 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/6017
+sto:IEC_61850-7-4:2010 sto:hasPublicationDate "2010-03-31"^^xsd:date .
+sto:IEC_61850-7-4:2010 sto:hasEdition "2.0" .
+sto:IEC_61850-7-4:2010 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61850-7-4:2010 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61850-7-4:2010 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6202
+sto:IEC_61968-3:2004 sto:hasPublicationDate "2004-03-08"^^xsd:date .
+sto:IEC_61968-3:2004 sto:hasEdition "1.0" .
+sto:IEC_61968-3:2004 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61968-3:2004 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-3:2004 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61968-3:2004 sto:hasPages "36"^^xsd:int .
+sto:IEC_61968-3:2004 sto:hasFileSize "601 KB" .
+sto:IEC_61968-3:2004 prov:wasRevisionOf sto:IEC_61968-3:2017 .
+sto:IEC_61968-3:2017 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61968-3:2017 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/27527
+sto:IEC_61968-3:2017 sto:hasPublicationDate "2017-04-11"^^xsd:date .
+sto:IEC_61968-3:2017 sto:hasEdition "2.0" .
+sto:IEC_61968-3:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61968-3:2017 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-3:2017 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6203
+sto:IEC_61968-4:2007 sto:hasPublicationDate "2007-07-11"^^xsd:date .
+sto:IEC_61968-4:2007 sto:hasEdition "1.0" .
+sto:IEC_61968-4:2007 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61968-4:2007 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-4:2007 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/64397
+# https://webstore.iec.ch/publication/22834
+sto:IEC_61968-6:2015 sto:hasPublicationDate "2015-07-07"^^xsd:date .
+sto:IEC_61968-6:2015 sto:hasEdition "1.0" .
+sto:IEC_61968-6:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61968-6:2015 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-6:2015 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/22537
+sto:IEC_61968-8:2015 sto:hasPublicationDate "2015-05-27"^^xsd:date .
+sto:IEC_61968-8:2015 sto:hasEdition "1.0" .
+sto:IEC_61968-8:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61968-8:2015 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-8:2015 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20183
+sto:IEC_61968-9:2009 sto:hasPublicationDate "2009-09-16"^^xsd:date .
+sto:IEC_61968-9:2009 sto:hasEdition "1.0" .
+sto:IEC_61968-9:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61968-9:2009 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-9:2009 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61968-9:2009 sto:hasPages "257"^^xsd:int .
+sto:IEC_61968-9:2009 sto:hasFileSize "2745 KB" .
+sto:IEC_61968-9:2009 prov:wasRevisionOf sto:IEC_61968-9:2013 .
+sto:IEC_61968-9:2013 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61968-9:2013 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/6204
+sto:IEC_61968-9:2013 sto:hasPublicationDate "2013-10-16"^^xsd:date .
+sto:IEC_61968-9:2013 sto:hasEdition "2.0" .
+sto:IEC_61968-9:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61968-9:2013 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61968-9:2013 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6208
+sto:IEC_61970-1:2005 sto:hasPublicationDate "2005-12-07"^^xsd:date .
+sto:IEC_61970-1:2005 sto:hasEdition "1.0" .
+sto:IEC_61970-1:2005 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-1:2005 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-1:2005 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/20189
+sto:IEC_61970-301:2003 sto:hasPublicationDate "2003-11-26"^^xsd:date .
+sto:IEC_61970-301:2003 sto:hasEdition "1.0" .
+sto:IEC_61970-301:2003 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-301:2003 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2003 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-301:2003 sto:hasPages "369"^^xsd:int .
+sto:IEC_61970-301:2003 sto:hasFileSize "2709 KB" .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2016 .
+sto:IEC_61970-301:2016 sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016 sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2016_RLV .
+sto:IEC_61970-301:2016_RLV sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016_RLV sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2013 .
+sto:IEC_61970-301:2013 sto:hasEdition "5.0"^^xsd:double .
+sto:IEC_61970-301:2013 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2013 .
+sto:IEC_61970-301:2013 sto:hasEdition "4.0"^^xsd:double .
+sto:IEC_61970-301:2013 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2011 .
+sto:IEC_61970-301:2011 sto:hasEdition "3.0"^^xsd:double .
+sto:IEC_61970-301:2011 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2003 prov:wasRevisionOf sto:IEC_61970-301:2009 .
+sto:IEC_61970-301:2009 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61970-301:2009 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/20190
+sto:IEC_61970-301:2009 sto:hasPublicationDate "2009-04-07"^^xsd:date .
+sto:IEC_61970-301:2009 sto:hasEdition "2.0" .
+sto:IEC_61970-301:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61970-301:2009 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2009 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-301:2009 sto:hasPages "211"^^xsd:int .
+sto:IEC_61970-301:2009 sto:hasFileSize "2348 KB" .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2016 .
+sto:IEC_61970-301:2016 sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016 sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2016_RLV .
+sto:IEC_61970-301:2016_RLV sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016_RLV sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2013 .
+sto:IEC_61970-301:2013 sto:hasEdition "5.0"^^xsd:double .
+sto:IEC_61970-301:2013 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2013 .
+sto:IEC_61970-301:2013 sto:hasEdition "4.0"^^xsd:double .
+sto:IEC_61970-301:2013 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2011 .
+sto:IEC_61970-301:2011 sto:hasEdition "3.0"^^xsd:double .
+sto:IEC_61970-301:2011 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2009 prov:wasRevisionOf sto:IEC_61970-301:2003 .
+sto:IEC_61970-301:2003 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_61970-301:2003 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/20191
+sto:IEC_61970-301:2011 sto:hasPublicationDate "2011-08-26"^^xsd:date .
+sto:IEC_61970-301:2011 sto:hasEdition "3.0" .
+sto:IEC_61970-301:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-301:2011 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2011 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-301:2011 sto:hasPages "533"^^xsd:int .
+sto:IEC_61970-301:2011 sto:hasFileSize "4841 KB" .
+# https://webstore.iec.ch/publication/20192
+sto:IEC_61970-301:2013 sto:hasPublicationDate "2013-05-23"^^xsd:date .
+sto:IEC_61970-301:2013 sto:hasEdition "4.0" .
+sto:IEC_61970-301:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-301:2013 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2013 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-301:2013 sto:hasPages "644"^^xsd:int .
+sto:IEC_61970-301:2013 sto:hasFileSize "5466 KB" .
+# https://webstore.iec.ch/publication/6210
+sto:IEC_61970-301:2013 sto:hasPublicationDate "2013-12-13"^^xsd:date .
+sto:IEC_61970-301:2013 sto:hasEdition "5.0" .
+sto:IEC_61970-301:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-301:2013 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2013 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-301:2013 sto:hasPages "766"^^xsd:int .
+sto:IEC_61970-301:2013 sto:hasFileSize "8022 KB" .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2016 .
+sto:IEC_61970-301:2016 sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016 sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2016_RLV .
+sto:IEC_61970-301:2016_RLV sto:hasEdition "6.0"^^xsd:double .
+sto:IEC_61970-301:2016_RLV sto:hasStatus "Valid"@en .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2013 .
+sto:IEC_61970-301:2013 sto:hasEdition "4.0"^^xsd:double .
+sto:IEC_61970-301:2013 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2011 .
+sto:IEC_61970-301:2011 sto:hasEdition "3.0"^^xsd:double .
+sto:IEC_61970-301:2011 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2009 .
+sto:IEC_61970-301:2009 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61970-301:2009 sto:hasStatus "Revised"@en .
+sto:IEC_61970-301:2013 prov:wasRevisionOf sto:IEC_61970-301:2003 .
+sto:IEC_61970-301:2003 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_61970-301:2003 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/31356
+sto:IEC_61970-301:2016 sto:hasPublicationDate "2016-12-16"^^xsd:date .
+sto:IEC_61970-301:2016 sto:hasEdition "6.0" .
+sto:IEC_61970-301:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-301:2016 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2016 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/59669
+sto:IEC_61970-301:2016_RLV sto:hasPublicationDate "2016-12-16"^^xsd:date .
+sto:IEC_61970-301:2016_RLV sto:hasEdition "6.0" .
+sto:IEC_61970-301:2016_RLV sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_61970-301:2016_RLV sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-301:2016_RLV sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/6212
+sto:IEC_61970-452:2013 sto:hasPublicationDate "2013-08-12"^^xsd:date .
+sto:IEC_61970-452:2013 sto:hasEdition "1.0" .
+sto:IEC_61970-452:2013 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-452:2013 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-452:2013 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-452:2013 sto:hasPages "244"^^xsd:int .
+sto:IEC_61970-452:2013 sto:hasFileSize "2015 KB" .
+sto:IEC_61970-452:2013 prov:wasRevisionOf sto:IEC_61970-452:2017 .
+sto:IEC_61970-452:2017 sto:hasEdition "3.0"^^xsd:double .
+sto:IEC_61970-452:2017 sto:hasStatus "Valid"@en .
+sto:IEC_61970-452:2013 prov:wasRevisionOf sto:IEC_61970-452:2015 .
+sto:IEC_61970-452:2015 sto:hasEdition "2.0"^^xsd:double .
+sto:IEC_61970-452:2015 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/22090
+sto:IEC_61970-452:2015 sto:hasPublicationDate "2015-04-09"^^xsd:date .
+sto:IEC_61970-452:2015 sto:hasEdition "2.0" .
+sto:IEC_61970-452:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-452:2015 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-452:2015 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+sto:IEC_61970-452:2015 sto:hasPages "203"^^xsd:int .
+sto:IEC_61970-452:2015 sto:hasFileSize "2238 KB" .
+sto:IEC_61970-452:2015 prov:wasRevisionOf sto:IEC_61970-452:2017 .
+sto:IEC_61970-452:2017 sto:hasEdition "3.0"^^xsd:double .
+sto:IEC_61970-452:2017 sto:hasStatus "Valid"@en .
+sto:IEC_61970-452:2015 prov:wasRevisionOf sto:IEC_61970-452:2013 .
+sto:IEC_61970-452:2013 sto:hasEdition "1.0"^^xsd:double .
+sto:IEC_61970-452:2013 sto:hasStatus "Revised"@en .
+# https://webstore.iec.ch/publication/30444
+sto:IEC_61970-452:2017 sto:hasPublicationDate "2017-07-26"^^xsd:date .
+sto:IEC_61970-452:2017 sto:hasEdition "3.0" .
+sto:IEC_61970-452:2017 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61970-452:2017 sto:hasTechnicalCommittee "TC 57 - Power systems management and associated information exchange" .
+sto:IEC_61970-452:2017 sto:hasICS "33.200 - Telecontrol. Telemetering" .
+# https://webstore.iec.ch/publication/9602
+sto:ISO/IEC_11404:2007 sto:hasPublicationDate "2007-12-06"^^xsd:date .
+sto:ISO/IEC_11404:2007 sto:hasEdition "2.0" .
+sto:ISO/IEC_11404:2007 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_11404:2007 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 32 - Data management and interchange" .
+sto:ISO/IEC_11404:2007 sto:hasICS "35.060 - Languages used in information technology" .
+sto:ISO/IEC_11404:2007 sto:hasPages "96"^^xsd:int .
+sto:ISO/IEC_11404:2007 sto:hasFileSize "741 KB" .
+# https://webstore.iec.ch/publication/10255
+sto:ISO/IEC_15408-1:2009 sto:hasPublicationDate "2009-12-03"^^xsd:date .
+sto:ISO/IEC_15408-1:2009 sto:hasEdition "3.0" .
+sto:ISO/IEC_15408-1:2009 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_15408-1:2009 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_15408-1:2009 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_15408-1:2009 sto:hasPages "65"^^xsd:int .
+sto:ISO/IEC_15408-1:2009 sto:hasFileSize "958 KB" .
+# https://webstore.iec.ch/publication/11302
+sto:ISO/IEC_27018:2014 sto:hasPublicationDate "2014-07-29"^^xsd:date .
+sto:ISO/IEC_27018:2014 sto:hasEdition "1.0" .
+sto:ISO/IEC_27018:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_27018:2014 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_27018:2014 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_27018:2014 sto:hasPages "23"^^xsd:int .
+sto:ISO/IEC_27018:2014 sto:hasFileSize "515 KB" .
+sto:ISO/IEC_27018:2014 prov:wasRevisionOf sto:ISO/IEC_27018:2019 .
+sto:ISO/IEC_27018:2019 sto:hasEdition "2.0"^^xsd:double .
+sto:ISO/IEC_27018:2019 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/11304
+sto:ISO/IEC_27031:2011 sto:hasPublicationDate "2011-03-01"^^xsd:date .
+sto:ISO/IEC_27031:2011 sto:hasEdition "1.0" .
+sto:ISO/IEC_27031:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:ISO/IEC_27031:2011 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_27031:2011 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_27031:2011 sto:hasPages "37"^^xsd:int .
+sto:ISO/IEC_27031:2011 sto:hasFileSize "2231 KB" .
+# https://webstore.iec.ch/publication/11314
+sto:ISO/IEC_27036-1:2014 sto:hasPublicationDate "2014-03-24"^^xsd:date .
+sto:ISO/IEC_27036-1:2014 sto:hasEdition "1.0" .
+sto:ISO/IEC_27036-1:2014 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_27036-1:2014 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_27036-1:2014 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_27036-1:2014 sto:hasPages "13"^^xsd:int .
+sto:ISO/IEC_27036-1:2014 sto:hasFileSize "498 KB" .
+# https://webstore.iec.ch/publication/11322
+sto:ISO/IEC_29100:2011 sto:hasPublicationDate "2011-12-05"^^xsd:date .
+sto:ISO/IEC_29100:2011 sto:hasEdition "1.0" .
+sto:ISO/IEC_29100:2011 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_29100:2011 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_29100:2011 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_29100:2011 sto:hasPages "21"^^xsd:int .
+sto:ISO/IEC_29100:2011 sto:hasFileSize "450 KB" .
+sto:ISO/IEC_29100:2011 prov:wasRevisionOf sto:ISO/IEC_29100:2011/AMD1:2018 .
+sto:ISO/IEC_29100:2011/AMD1:2018 sto:hasEdition "1.0"^^xsd:double .
+sto:ISO/IEC_29100:2011/AMD1:2018 sto:hasStatus "Valid"@en .
+# https://webstore.iec.ch/publication/23118
+sto:ISO/IEC_29190:2015 sto:hasPublicationDate "2015-08-10"^^xsd:date .
+sto:ISO/IEC_29190:2015 sto:hasEdition "1.0" .
+sto:ISO/IEC_29190:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:ISO/IEC_29190:2015 sto:hasTechnicalCommittee "ISO/IEC JTC 1/SC 27 - Information security, cybersecurity and privacy protection" .
+sto:ISO/IEC_29190:2015 sto:hasICS "35.030 - IT Security " .
+sto:ISO/IEC_29190:2015 sto:hasPages "15"^^xsd:int .
+sto:ISO/IEC_29190:2015 sto:hasFileSize "441 KB" .
+# https://webstore.iec.ch/publication/22636
+sto:IEC_61804-3:2015 sto:hasPublicationDate "2015-06-09"^^xsd:date .
+sto:IEC_61804-3:2015 sto:hasEdition "3.0" .
+sto:IEC_61804-3:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61804-3:2015 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_61804-3:2015 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/23481
+sto:IEC_61804-4:2015 sto:hasPublicationDate "2015-10-07"^^xsd:date .
+sto:IEC_61804-4:2015 sto:hasEdition "1.0" .
+sto:IEC_61804-4:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61804-4:2015 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_61804-4:2015 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/22637
+sto:IEC_61804-5:2015 sto:hasPublicationDate "2015-06-09"^^xsd:date .
+sto:IEC_61804-5:2015 sto:hasEdition "1.0" .
+sto:IEC_61804-5:2015 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng>, <http://lexvo.org/id/iso639-3/fra> .
+sto:IEC_61804-5:2015 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_61804-5:2015 sto:hasICS "25.040.40 - Industrial process measurement and control" .
+# https://webstore.iec.ch/publication/25315
+sto:IEC_PAS_62264-6:2016 sto:hasPublicationDate "2016-07-05"^^xsd:date .
+sto:IEC_PAS_62264-6:2016 sto:hasEdition "1.0" .
+sto:IEC_PAS_62264-6:2016 sto:hasAvailableLanguage <http://lexvo.org/id/iso639-3/eng> .
+sto:IEC_PAS_62264-6:2016 sto:hasTechnicalCommittee "TC 65/SC 65E - Devices and integration in enterprise systems" .
+sto:IEC_PAS_62264-6:2016 sto:hasICS "25.040.99 - Other industrial automation systems" .


### PR DESCRIPTION
This is the first version of the JS crawler extracting metadata from IEC standards. The output is close to Turtle but requires a bit of further cleaning. Several features can be improved however, for instance I just noticed that 'Withdrawn' tags are also available. 'Real crawling', meaning following links to further standards, has not yet been activated but is easy to implement.